### PR TITLE
Accomodate for async Web Components polyfill

### DIFF
--- a/test-fixture.html
+++ b/test-fixture.html
@@ -108,15 +108,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     stamp: function (fixtureTemplate, model) {
+      var stamped;
       // Check if we are dealing with a "stampable" `<template>`. This is a
       // vaguely defined special case of a `<template>` that is a custom
       // element with a public `stamp` method that implements some manner of
       // data binding.
       if (fixtureTemplate.stamp) {
-        var stamped = fixtureTemplate.stamp(model);
+        stamped = fixtureTemplate.stamp(model);
         // We leak Polymer specifics a little; if there is an element `root`, we
         // want that to be returned.
-        return stamped.root || stamped;
+        stamped = stamped.root || stamped;
 
       // Otherwise, we fall back to standard HTML templates, which do not have
       // any sort of binding support.
@@ -124,8 +125,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (model) {
           console.warn(this, 'was given a model to stamp, but the template is not of a bindable type');
         }
-        return document.importNode(fixtureTemplate.content, true);
+
+        stamped = document.importNode(fixtureTemplate.content, true);
+
+        // Immediately upgrade the subtree if we are dealing with async
+        // Web Components polyfill.
+        // https://github.com/Polymer/polymer/blob/0.8-preview/src/features/mini/template.html#L52
+        if (window.CustomElements && CustomElements.upgradeSubtree) {
+          CustomElements.upgradeSubtree(stamped);
+        }
       }
+
+      return stamped;
     }
   };
 


### PR DESCRIPTION
The Web Components polyfill upgrades nested custom elements
asynchronously. This change forces the upgrade to be synchronous if the
polyfill is detected.
