### PR TITLE
Fix Safari 7.

### DIFF
--- a/test-fixture.html
+++ b/test-fixture.html
@@ -62,13 +62,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         console.error('Error stamping', fixtureTemplate, error);
         throw error;
       }
-      fixturedElements = [];
-      fixturedElement = fixturedFragment.firstElementChild;
 
-      while (fixturedElement) {
-        fixturedElements.push(fixturedElement);
-        fixturedElement = fixturedElement.nextElementSibling;
-      }
+      fixturedElements = this.collectElementChildren(fixturedFragment);
 
       this.appendChild(fixturedFragment);
       this._elementsFixtured = true;
@@ -94,6 +89,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.generatedDomStack = [];
 
       this._elementsFixtured = false;
+    },
+
+    collectElementChildren: function (parent) {
+      // Note: Safari 7.1 does not support `firstElementChild` or
+      // `nextElementSibling`, so we do things the old-fashioned way:
+      var elements = [];
+      var child = parent.firstChild;
+
+      while (child) {
+        if (child.nodeType !== Node.TEXT_NODE) {
+          elements.push(child);
+        }
+
+        child = child.nextSibling;
+      }
+
+      return elements;
     },
 
     removeElements: function (elements) {

--- a/test/test-fixture.html
+++ b/test/test-fixture.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>test-fixture</title>
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../test-fixture-mocha.js"></script>
 


### PR DESCRIPTION
Use `firstChild` and `nextSibling` instead of `firstElementChild` and `nextElementSibling`.
