### PR TITLE
Don't pin WCT

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "webcomponentsjs": "~0.5.3"
   },
   "devDependencies": {
-    "web-component-tester": "~2.0.5"
+    "web-component-tester": "*"
   }
 }


### PR DESCRIPTION
`~2.0.5` is shorthand for `>=2.0.5, <2.1.0`. You probably meant `^2.0.5` (which is `>=2.0.5, <3.0.0`)

(if you're using `~`, chances are that you're doing it wrong)

However, I'd also argue that we always want the latest version of WCT to force us to keep it up to date
