### PR TITLE
Update README for Polymer 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Data-binding systems are also supported, as long as your (custom) template
 elements define a `stamp(model)` method that returns a document fragment. This
 allows you to stamp out templates w/ custom models for your fixtures.
 
-For example, using Polymer 0.8's `x-template`:
+For example, using Polymer 1.0  `dom-template`:
 
 ```html
 <test-fixture id="bound">
-  <template is="x-template">
+  <template is="dom-template">
     <span>{{greeting}}</span>
   </template>
 </test-fixture>
@@ -81,6 +81,11 @@ the model:
 
 ```js
 var bound = fixture('bound', {greeting: 'ohai thurr'});
+```
+
+```js
+var bound = document.findElementById('bound');
+bound.create({greeting: 'ohai thurr'});
 ```
 
 ## The problem being addressed


### PR DESCRIPTION
In polymer 1.0  `x-template` was renamed to `dom-template`.

Added another example using `.create` directly on the `test-fixture` element.
